### PR TITLE
fix resize changing intrinsic parameters bug

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -50,8 +50,8 @@ def image_stream(imagedir, calib, stride):
         image = torch.as_tensor(image).permute(2, 0, 1)
 
         intrinsics = torch.as_tensor([fx, fy, cx, cy])
-        intrinsics[0:2] *= (w1 / w0)
-        intrinsics[2:4] *= (h1 / h0)
+        intrinsics[0::2] *= (w1 / w0)
+        intrinsics[1::2] *= (h1 / h0)
 
         yield t, image, intrinsics
 


### PR DESCRIPTION
I think the scale factor should be multiplied by (fx, cx) and (fy, cy), respectively. However,  it will not have much effect since the scale is too close and only the int(*) will let them different. It should be intrinsics[0::2] and intrinsics[1::2] in case the scale is different.
Please check if the modification is right.