### PR TITLE
Update factor_graph.py

### DIFF
--- a/droid_slam/factor_graph.py
+++ b/droid_slam/factor_graph.py
@@ -165,8 +165,8 @@ class FactorGraph:
     def rm_keyframe(self, ix):
         """ drop edges from factor graph """
 
-
         with self.video.get_lock():
+            self.video.tstamp[ix] = self.video.tstamp[ix+1]
             self.video.images[ix] = self.video.images[ix+1]
             self.video.poses[ix] = self.video.poses[ix+1]
             self.video.disps[ix] = self.video.disps[ix+1]


### PR DESCRIPTION
Currently tstamp is not aligned to other attributes in depth_video, such as images, poses, disps. So I add  self.video.tstamp[ix] = self.video.tstamp[ix+1] to fix this bug.