### PR TITLE
[Bug fix] Fix net indexing in first keyframe

### DIFF
--- a/droid_slam/motion_filter.py
+++ b/droid_slam/motion_filter.py
@@ -69,7 +69,7 @@ class MotionFilter:
         if self.video.counter.value == 0:
             net, inp = self.__context_encoder(inputs[:,[0]])
             self.net, self.inp, self.fmap = net, inp, gmap
-            self.video.append(tstamp, image[0], Id, 1.0, depth, intrinsics / 8.0, gmap, net[0,0], inp[0,0])
+            self.video.append(tstamp, image[0], Id, 1.0, depth, intrinsics / 8.0, gmap, net[0], inp[0])
 
         ### only add new frame if there is enough motion ###
         else:                


### PR DESCRIPTION
**Description**
The main branch indexes the net features in a way that results in using only the first channel out of the 128 channels during BA. A simple change fixes that matching the indexing happening for the rest of the keyframes. Qualitative improvement in reconstruction occurs when we have limited number of keyframes.

**Issue details and fix**
We can see that there is a difference in indexing when adding the features of the keyframes to our video depth obj between the [first keyframe](https://github.com/princeton-vl/DROID-SLAM/blob/2dfd39f0dcad44012ca7bbb8aa70b55edbfa9c99/droid_slam/motion_filter.py#L72) and the [rest of the keyframes](https://github.com/princeton-vl/DROID-SLAM/blob/2dfd39f0dcad44012ca7bbb8aa70b55edbfa9c99/droid_slam/motion_filter.py#L88).

One could think that the features have different shapes in the two lines of code, but they do not. The function producing the features (___context_encoder_) is given the same shape of inputs in both cases ([first keyframe](https://github.com/princeton-vl/DROID-SLAM/blob/2dfd39f0dcad44012ca7bbb8aa70b55edbfa9c99/droid_slam/motion_filter.py#L70), [rest of keyframes](https://github.com/princeton-vl/DROID-SLAM/blob/2dfd39f0dcad44012ca7bbb8aa70b55edbfa9c99/droid_slam/motion_filter.py#L86)). One could think that _inputs_ has different shapes in both cases, but we can see it is being indexed in the [same way aside from the keyframe indexing branching](https://github.com/princeton-vl/DROID-SLAM/blob/2dfd39f0dcad44012ca7bbb8aa70b55edbfa9c99/droid_slam/motion_filter.py#L62). This was verified using a debugger not just by deduction. 

**Recommendation**
I do not recommend merging this PR without further testing. I am opening this PR to flag the issue, have a discussion about it especially regarding if I am misunderstanding the bug or not, and allowing others (or me) to perform full test for it before merging.

**Points to consider**
1. I do not see anything in the training code that assumes the first keyframe will have 1-channel features, but I understand the published code of training is different than the one used to train the pretrained checkpoint as can be inferred from [here](https://github.com/princeton-vl/DROID-SLAM/blob/2dfd39f0dcad44012ca7bbb8aa70b55edbfa9c99/droid_slam/droid.py#L45).
2. It could be the case that somehow this improves performance. There is no reason to believe that, but statistics are not easy to grasp.